### PR TITLE
Fix speaker photos resize

### DIFF
--- a/priv/site/_includes/css/components/Speakers.scss
+++ b/priv/site/_includes/css/components/Speakers.scss
@@ -259,6 +259,7 @@
       > .photo {
         flex: 1;
         min-width: 50%;
+        align-self: flex-end;
 
         margin: 0;
 
@@ -268,7 +269,6 @@
 
         > img {
           width: 100%;
-          height: 100%;;
           max-height: 100%;
         }
       }


### PR DESCRIPTION
In intermediate screen sizes, the speakers photo was stretching.

To fix it, I took some design liberties of sticking it to the bottom:

<img width="1387" alt="Screenshot 2021-04-06 at 18 42 32" src="https://user-images.githubusercontent.com/4325027/113755197-f4a5bd80-9707-11eb-9d49-d2360eec59ec.png">