### PR TITLE
Add Homepage Marquee Color

### DIFF
--- a/priv/site/_includes/css/components/Info.scss
+++ b/priv/site/_includes/css/components/Info.scss
@@ -276,6 +276,7 @@
     span {
       margin: 0 var(--s-4);
       text-transform: uppercase;
+      color: var(--c-white);
     }
   }
 }


### PR DESCRIPTION
- Issue Fix : Homepage - Marquee #40

<img width="1117" alt="Captura de ecrã 2021-04-29, às 11 42 47" src="https://user-images.githubusercontent.com/52913878/116538890-0a11a000-a8e0-11eb-830c-4cf905833638.png">
