### PR TITLE
Add Color White to Sponsor Button on Mobile Footer

### DIFF
--- a/priv/site/_includes/css/components/Links.scss
+++ b/priv/site/_includes/css/components/Links.scss
@@ -36,3 +36,8 @@
   }
 
 }
+
+.Footer--alt .BigLink.transparent {
+  color: var(--c-white);
+  border-color: var(--c-white);
+}


### PR DESCRIPTION
- Button Sponsor On Alternative Mobile Footer should be color and border white

<img width="363" alt="Captura de ecrã 2021-04-30, às 17 04 27" src="https://user-images.githubusercontent.com/52913878/116722313-242daa00-a9d6-11eb-8596-d2d073471171.png">
