### PR TITLE
Remove CFPs from Speakers page

### DIFF
--- a/priv/site/_includes/speakers/hero.slime
+++ b/priv/site/_includes/speakers/hero.slime
@@ -18,9 +18,3 @@
             li
               span.Speakers-listSpeaker = speaker[:name]
               span.Speakers-listTitle = speaker[:tagline]
-
-        = for _ <- 1..7 do
-          = link @env, to: papercall_url() do
-            li
-              span.Speakers-listSpeaker THIS COULD BE YOU!
-              span.Speakers-listTitle CFP OPEN


### PR DESCRIPTION
Why:
* No longer needed